### PR TITLE
Fix container_name

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -142,9 +142,8 @@ module.exports = async function (docker, projectName, recipe, output, options) {
     if (service.volumes) {
       servicesTools.buildVolumes(service.volumes, opts);
     }
-
-    if (service.name !== undefined) {
-      opts.Name = service.container_name || serviceName;
+    if (service.container_name !== undefined) {
+      opts.name = service.container_name;
     }
     if (service.domainname !== undefined) {
       opts.Domainname = service.domainname;


### PR DESCRIPTION
Hi,

First of all, thanks for your great dockerode & dockerode-compose projects 👍 

I detected & fixed an issue when a a `container-name` is defined on a docker-compose service.

E.g.
```yaml
  traefik_service:
    image: traefik:2.5.3
    container_name: traefik
```

