### PR TITLE
Add auth to compose pull

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -59,14 +59,14 @@ class Compose {
     }
   }
 
-  async pull(serviceN, options) {
+  async pull(serviceN, options, auth) {
     options = options || {};
     var streams = [];
     var serviceNames = (serviceN === undefined || serviceN === null) ? tools.sortServices(this.recipe) : [serviceN];
     for (var serviceName of serviceNames) {
       var service = this.recipe.services[serviceName];
       try {
-        var streami = await this.docker.pull(service.image);
+        var streami = await this.docker.pull(service.image, auth);
         streams.push(streami);
 
         if (options.verbose === true) {


### PR DESCRIPTION
hey,

i will tackle the auth topic in the next weeks!

i started working around it by using just dockerode:
```ts
    const requiredImages: string[] = []
    for (const [_, value] of Object.entries(getServiceInstance().recipe.services)) {
        requiredImages.push((value as any).image)
    }
    await Promise.all(requiredImages.map(async (image: string) => {
        try {
            console.log("pulling image:", image)
            if (image.startsWith("localhost:15004/")) {
                const options = {
                    // authconfig: {
                    //     username: config.regestryUser,
                    //     password: config.registryPw,
                    // }
                }
                await pullImage(image, options)
            } else {
                await pullImage(image)
            }
        } catch (error: any) {
            console.error(image, "-->", error)
        }
    }))
```

but this has some flavour ;)

just passing the auth options like in this PR will probably not be enough because not all images of a service are exclusively from one Registry...

so for beeing able to use it in a common way we probably need to pass a array of auth options to the compose pull function so we can try to figure out from which registry we need to pull with the correct auth options.

https://github.com/apocas/dockerode-compose/issues/28