### PR TITLE
Explicit naming for Docker containers in docker-compose files

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -14,7 +14,7 @@ class Compose {
     this.docker = dockerode;
 
     if (file === undefined) {
-      throw new Error('please specify a file and a project name');
+      throw new Error('please specify a file');
     }
 
     this.file = file;
@@ -28,7 +28,7 @@ class Compose {
     this.projectName = this.recipe.name || projectName;
 
     if (this.projectName === undefined) {
-      throw new Error('please specify a file and a project name');
+      throw new Error('please specify a project name');
     }
   }
 

--- a/compose.js
+++ b/compose.js
@@ -13,17 +13,22 @@ class Compose {
   constructor(dockerode, file, projectName) {
     this.docker = dockerode;
 
-    if (file === undefined || projectName === undefined) {
+    if (file === undefined) {
       throw new Error('please specify a file and a project name');
     }
 
     this.file = file;
-    this.projectName = projectName;
 
     try {
       this.recipe = yaml.load(fs.readFileSync(file, 'utf8'));
     } catch (e) {
       throw e;
+    }
+
+    this.projectName = this.recipe.name || projectName;
+
+    if (this.projectName === undefined) {
+      throw new Error('please specify a file and a project name');
     }
   }
 

--- a/lib/services.js
+++ b/lib/services.js
@@ -8,7 +8,8 @@ async function down(docker, projectName, recipe, output, options) {
   var services = [];
   var serviceNames = tools.sortServices(recipe);
   for (var serviceName of serviceNames) {
-    let container = docker.getContainer(projectName + '_' + serviceName + '_1');
+    let containerName = recipe.services[serviceName].container_name || servicesTools.getContainerName(projectName, serviceName);
+    let container = docker.getContainer(containerName);
 
     try {
       await container.stop();
@@ -152,7 +153,7 @@ async function up(docker, projectName, recipe, output, options) {
     }
 
     var opts = {
-      name: projectName + '_' + serviceName + '_1',
+      name: service.container_name || servicesTools.getContainerName(projectName, serviceName),
       Image: service.image,
       HostConfig: servicesTools.buildHostConfig(
         projectName,

--- a/test/assets/test_build_named/build_things/Dockerfile
+++ b/test/assets/test_build_named/build_things/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu
+
+RUN \
+  apt-get update && \
+  apt-get install -y nginx && service nginx start
+
+CMD ["bash"]

--- a/test/assets/test_build_named/docker-compose.yml
+++ b/test/assets/test_build_named/docker-compose.yml
@@ -1,0 +1,6 @@
+name: custom_project_name
+
+services:
+  frontend:
+    container_name: custom_project_name_frontend
+    build: ./build_things

--- a/test/compose.js
+++ b/test/compose.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect,
 var compose = require('./spec_helper').compose;
 var compose_complex = require('./spec_helper').compose_complex;
 var compose_build = require('./spec_helper').compose_build;
+var compose_named = require('./spec_helper').compose_named;
 var docker = require('./spec_helper').docker;
 
 describe('compose', function () {
@@ -163,6 +164,57 @@ describe('compose', function () {
         expect(listVolumes.Volumes).to.be.empty
         expect(listVolumes.Warnings).to.be.null
         let listNetworks = await docker.listNetworks({ 'filters': {"label":[`com.docker.compose.project=${compose.projectName}`]}})
+        expect(listNetworks).to.be.empty
+        done();
+      })();
+    });
+  });
+
+  describe('#up_build_named', function () {
+    it("should do compose up example with build", function (done) {
+      this.timeout(300000);
+      (async () => {
+          var report = await compose_named.up();
+          expect(report.services).to.be.ok;
+          done();
+      })();
+    });
+    it("should do compose up example with build(verbose)", function (done) {
+      this.timeout(300000);
+      (async () => {
+        var report = await compose_named.up({ 'verbose': true });
+        expect(report.services).to.be.ok;
+        done();
+      })();
+    });
+    afterEach('clean up', function (done) {
+      this.timeout(60000);
+      (async () => {
+        await compose_named.down({ volumes: true });
+        done();
+      })();
+    });
+  });
+
+  describe('#down_build_named', function () {
+    beforeEach('bring up', function (done) {
+      this.timeout(300000);
+      (async () => {
+        await compose_named.up();
+        done();
+      })();
+    });
+    it("should do compose down example with build", function (done) {
+      this.timeout(60000);
+      (async () => {
+        await compose_named.down({volumes: true});
+        let projectName = compose_named.recipe.name || compose_named.projectName;
+        let listContainers = await docker.listContainers({ 'all': true, 'filters': {"label":[`com.docker.compose.project=${projectName}`]}});
+        expect(listContainers).to.be.empty
+        let listVolumes  = await docker.listVolumes({ 'filters': {"label":[`com.docker.compose.project=${projectName}`]}})
+        expect(listVolumes.Volumes).to.be.empty
+        expect(listVolumes.Warnings).to.be.null
+        let listNetworks = await docker.listNetworks({ 'filters': {"label":[`com.docker.compose.project=${projectName}`]}})
         expect(listNetworks).to.be.empty
         done();
       })();

--- a/test/spec_helper.js
+++ b/test/spec_helper.js
@@ -5,10 +5,12 @@ var docker = new Dockerode();
 var compose = new DockerodeCompose(docker, './test/assets/wordpress_original.yml', 'dockerodec_wordpress');
 var compose_complex = new DockerodeCompose(docker, './test/assets/complex_example/docker-compose.yml', 'dockerodec_complex');
 var compose_build = new DockerodeCompose(docker, './test/assets/test_build/docker-compose.yml', 'dockerodec_build');
+var compose_named = new DockerodeCompose(docker, './test/assets/test_build_named/docker-compose.yml');
 
 module.exports = {
   'docker': docker,
   'compose': compose,
   'compose_complex': compose_complex,
-  'compose_build': compose_build
+  'compose_build': compose_build,
+  'compose_named': compose_named
 }


### PR DESCRIPTION
This changes the handling of container names to allow explicit naming in the `docker-compose.yml` file for projects and containers. This approach aligns with the typical usage of Docker Compose, where users often run commands like `docker compose up -f path/to/docker-compose.yml` without specifying a project name. The project name is already specified in the `docker-compose.yml` and this makes the projectName optional when instantiating the `DockerodeCompose` class. 