### PR TITLE
Enhance buildDockerImage error handling and include all context files

### DIFF
--- a/lib/servicesTools.js
+++ b/lib/servicesTools.js
@@ -647,30 +647,48 @@ module.exports = {
     options
   ) {
     options = options || {};
-    if (dockerfile !== null) {
-      obj['dockerfile'] = path.basename(dockerfile);
-      let streami = await docker.buildImage(
-        {
-          context: buildPath,
-          src: [dockerfile],
-        },
-        obj
-      );
-      if (options.verbose === true) {
-        streami.pipe(process.stdout);
-      } else {
-        streami.pipe(stream.PassThrough());
-      }
-      await new Promise((fulfill) => streami.once('end', fulfill));
-    } else {
-      var tarStream = tar.pack(buildPath);
-      let streami = await docker.buildImage(tarStream, obj);
-      if (options.verbose === true) {
-        streami.pipe(process.stdout);
-      } else {
-        streami.pipe(stream.PassThrough());
-      }
-      await new Promise((fulfill) => streami.once('end', fulfill));
-    }
+    
+    return new Promise(async (resolve, reject) => {
+        try {
+            let stream;
+            if (dockerfile !== null) {
+                obj['dockerfile'] = path.basename(dockerfile);
+                stream = await docker.buildImage({
+                    context: buildPath,
+                    src: fs.readdirSync(buildPath)
+                }, obj);
+            } else {
+                var tarStream = tar.pack(buildPath);
+                stream = await docker.buildImage(tarStream, obj);
+            }
+
+            stream.on('data', (data) => {
+                const line = data.toString();
+                try {
+                    const parsedLine = JSON.parse(line);
+                    
+                    if (options.verbose === true) {
+                        process.stdout.write(line);
+                    }
+
+                    if (parsedLine.error) {
+                        reject(new Error(parsedLine.error));
+                    }
+                    if (parsedLine.errorDetail) {
+                        reject(new Error(parsedLine.errorDetail.message));
+                    }
+                } catch (e) {
+                    if (options.verbose === true) {
+                        process.stdout.write(line);
+                    }
+                }
+            });
+
+            stream.on('end', () => resolve());
+            stream.on('error', (error) => reject(error));
+        } catch (error) {
+            reject(error);
+        }
+    });
   },
 };

--- a/test/assets/test_build_context/build_things/Dockerfile
+++ b/test/assets/test_build_context/build_things/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu
+
+RUN \
+  apt-get update && \
+  apt-get install -y nginx && service nginx start
+
+COPY config.sh /docker-entrypoint-initdb.d/

--- a/test/assets/test_build_context/build_things/config.sh
+++ b/test/assets/test_build_context/build_things/config.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Copied script is copied"

--- a/test/assets/test_build_context/docker-compose.yml
+++ b/test/assets/test_build_context/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  frontend:
+    build:
+      context: ./build_things
+      dockerfile: Dockerfile

--- a/test/compose.js
+++ b/test/compose.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect,
 var compose = require('./spec_helper').compose;
 var compose_complex = require('./spec_helper').compose_complex;
 var compose_build = require('./spec_helper').compose_build;
+var compose_build_context = require('./spec_helper').compose_build_context;
 var docker = require('./spec_helper').docker;
 
 describe('compose', function () {
@@ -163,6 +164,56 @@ describe('compose', function () {
         expect(listVolumes.Volumes).to.be.empty
         expect(listVolumes.Warnings).to.be.null
         let listNetworks = await docker.listNetworks({ 'filters': {"label":[`com.docker.compose.project=${compose.projectName}`]}})
+        expect(listNetworks).to.be.empty
+        done();
+      })();
+    });
+  });
+
+  describe('#up_build_context', function () {
+    it("should do compose up example with build", function (done) {
+      this.timeout(300000);
+      (async () => {
+          var report = await compose_build_context.up();
+          expect(report.services).to.be.ok;
+          done();
+      })();
+    });
+    it("should do compose up example with build(verbose)", function (done) {
+      this.timeout(300000);
+      (async () => {
+        await compose_build_context.up({ 'verbose': true });
+        done();
+      })();
+    });
+    afterEach('clean up', function (done) {
+      this.timeout(60000);
+      (async () => {
+        await compose_build_context.down({ volumes: true });
+        done();
+      })();
+    });
+  });
+
+  describe('#down_build_context', function () {
+    beforeEach('bring up', function (done) {
+      this.timeout(300000);
+      (async () => {
+        await compose_build_context.up();
+        done();
+      })();
+    });
+    it("should do compose down example with build", function (done) {
+      this.timeout(60000);
+      (async () => {
+        await compose_build_context.down({volumes: true});
+        let projectName = compose_build_context.projectName;
+        let listContainers = await docker.listContainers({ 'all': true, 'filters': {"label":[`com.docker.compose.project=${projectName}`]}});
+        expect(listContainers).to.be.empty
+        let listVolumes  = await docker.listVolumes({ 'filters': {"label":[`com.docker.compose.project=${projectName}`]}})
+        expect(listVolumes.Volumes).to.be.empty
+        expect(listVolumes.Warnings).to.be.null
+        let listNetworks = await docker.listNetworks({ 'filters': {"label":[`com.docker.compose.project=${projectName}`]}})
         expect(listNetworks).to.be.empty
         done();
       })();

--- a/test/spec_helper.js
+++ b/test/spec_helper.js
@@ -5,10 +5,12 @@ var docker = new Dockerode();
 var compose = new DockerodeCompose(docker, './test/assets/wordpress_original.yml', 'dockerodec_wordpress');
 var compose_complex = new DockerodeCompose(docker, './test/assets/complex_example/docker-compose.yml', 'dockerodec_complex');
 var compose_build = new DockerodeCompose(docker, './test/assets/test_build/docker-compose.yml', 'dockerodec_build');
+var compose_build_context = new DockerodeCompose(docker, './test/assets/test_build_context/docker-compose.yml', 'dockerodec_build_copy');
 
 module.exports = {
   'docker': docker,
   'compose': compose,
   'compose_complex': compose_complex,
-  'compose_build': compose_build
+  'compose_build': compose_build,
+  'compose_build_context': compose_build_context
 }


### PR DESCRIPTION
This allows builds with an explicit `Dockerfile` to include files from the build context. The build process now includes all files in the specified build context directory. This is because Dockerode already respects the `.dockerignore` file, which means that while unnecessary files are filtered out, all relevant files must be present in the context for a successful build.

For example if you try to copy a script into the Docker image while using an explicit `Dockerfile` you would get this error:
`
{"errorDetail":{"message":"COPY failed: file not found in build context or excluded by .dockerignore: stat config.sh: file does not exist"},"error":"COPY failed: file not found in build context or excluded by .dockerignore: stat config.sh: file does not exist"}`

This also addresses issues related to error handling in the `buildDockerImage` function within the `lib/servicesTools.js` file. Previously, errors during the Docker image build process were failing silently, making it difficult to diagnose problems. This update enhances error detection and ensures that all relevant files in the build context directory are included in the build process.

